### PR TITLE
Fix u32 overflow in add_holding when combining lots

### DIFF
--- a/src/app/portfolio.rs
+++ b/src/app/portfolio.rs
@@ -43,10 +43,14 @@ impl App {
             if avg_price > 0.0 {
                 match (&self.pending_symbol, self.pending_lots) {
                     (Some(symbol), Some(lots)) => {
-                        self.config.add_holding(symbol, lots, avg_price);
-                        self.config.save()?;
-                        self.status_message =
-                            Some(format!("Added {} lots of {} @ {}", lots, symbol, avg_price));
+                        if self.config.add_holding(symbol, lots, avg_price) {
+                            self.config.save()?;
+                            self.status_message =
+                                Some(format!("Added {} lots of {} @ {}", lots, symbol, avg_price));
+                        } else {
+                            self.status_message =
+                                Some("Total lots would exceed maximum (4,294,967,295)".to_string());
+                        }
                     }
                     _ => {
                         self.status_message = Some("Missing symbol or lots data".to_string());


### PR DESCRIPTION
## Summary
- Replace plain `u32` addition with `checked_add` in `Config::add_holding()` to prevent overflow panic (debug) and silent data corruption (release)
- `add_holding` now returns `bool` — `false` when merging would exceed `u32::MAX`, leaving the existing holding unchanged
- Caller in `portfolio.rs` shows an error message on overflow instead of saving corrupted data

## Test plan
- [x] `add_holding_overflow_returns_false` — verifies overflow returns `false` and holding is untouched
- [x] `add_holding_normal_merge` — verifies weighted average calculation still works
- [x] `add_holding_new_symbol` — verifies new symbols are added correctly
- [x] All 5 tests pass, clippy clean

Closes #2