### PR TITLE
Fix loading indicator never rendering during network requests

### DIFF
--- a/src/app/news.rs
+++ b/src/app/news.rs
@@ -11,10 +11,15 @@ impl App {
             .any(|item| item.published_at >= cutoff && title_contains_ticker(&item.title, &sym))
     }
 
-    pub async fn refresh_news(&mut self) {
+    /// Set `rss_loading = true` and return the feed URLs.
+    pub fn prepare_news_refresh(&mut self) -> Vec<String> {
         self.rss_loading = true;
-        let urls = self.config.news_sources.clone();
-        match self.news_client.fetch_all(&urls).await {
+        self.config.news_sources.clone()
+    }
+
+    /// Execute the network fetch for news feeds and clear `rss_loading`.
+    pub async fn execute_news_refresh(&mut self, urls: &[String]) {
+        match self.news_client.fetch_all(urls).await {
             Ok(items) => {
                 self.news_items = items;
                 self.news_last_refresh = Some(tokio::time::Instant::now());


### PR DESCRIPTION
## Summary
- Split `refresh_quotes()` into `prepare_refresh()` + `execute_refresh()` so the event loop can draw the `[Loading...]` header between setting the flag and awaiting the network call
- Applied the same prepare/execute split to `refresh_news()` → `prepare_news_refresh()` + `execute_news_refresh()` for the `[Loading feeds...]` indicator
- Added `refresh_and_draw()` / `refresh_news_and_draw()` helpers in `run_app` that draw a frame (with loading visible) before awaiting I/O

Closes #3

## Test plan
- [x] `cargo build` compiles cleanly
- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` — all 5 tests pass
- [x] Manual: run the app, observe `[Loading...]` in the header during quote refresh
- [x] Manual: switch to News view, observe `[Loading feeds...]` during RSS fetch