### PR TITLE
Fix misleading comment, dead field, and misleading function name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ src/
 
 **Responsive Columns**: `ColumnDef` structs with priority tiers (1=always visible, 4=only on wide terminals). `visible_columns()` greedily includes columns from highest to lowest priority until available width is exhausted. Stretch columns (Name for watchlist, Value for portfolio) absorb extra space via `Constraint::Min()`.
 
-**Column Sorting**: `SortDirection` enum with `cycle_sort_column()` / `toggle_sort_direction()`. Sort applied in `get_filtered_watchlist()` / `get_filtered_portfolio()` / `get_filtered_news()` after search filtering. Free functions `compare_watchlist_column()` / `compare_portfolio_column()` / `compare_news_column()` handle per-column type-aware comparison. Export functions use `get_sorted_watchlist()` (insertion order, not sorted).
+**Column Sorting**: `SortDirection` enum with `cycle_sort_column()` / `toggle_sort_direction()`. Sort applied in `get_filtered_watchlist()` / `get_filtered_portfolio()` / `get_filtered_news()` after search filtering. Free functions `compare_watchlist_column()` / `compare_portfolio_column()` / `compare_news_column()` handle per-column type-aware comparison. Export functions use `get_raw_watchlist()` (insertion order, not sorted).
 
 **Selection via Filtered View**: `selected_index` / `portfolio_selected` / `news_selected` are indices into the **filtered/sorted** list, not the raw list. All operations (delete, detail view, navigation bounds) must resolve through the filtered list helpers.
 

--- a/src/api/yahoo.rs
+++ b/src/api/yahoo.rs
@@ -225,7 +225,7 @@ impl YahooClient {
             }
         }
 
-        // Pattern 2: "CrsrfToken":"value"
+        // Pattern 2: "CrumbStore":{"crumb":"value"}
         if let Some(start) = html.find("\"CrumbStore\":{\"crumb\":\"") {
             let start = start + 23;
             if let Some(end) = html[start..].find('"') {

--- a/src/app/export.rs
+++ b/src/app/export.rs
@@ -101,7 +101,7 @@ impl App {
 
     fn export_watchlist_csv(&self) -> String {
         let mut csv = String::from("Symbol,Name,Price,Change,Change%,Open,High,Low,Volume\n");
-        for (symbol, quote) in self.get_sorted_watchlist() {
+        for (symbol, quote) in self.get_raw_watchlist() {
             if let Some(q) = quote {
                 csv.push_str(&format!(
                     "{},{},{:.2},{:.2},{:.2},{:.2},{:.2},{:.2},{}\n",
@@ -124,7 +124,7 @@ impl App {
 
     fn export_watchlist_json(&self) -> String {
         let data: Vec<serde_json::Value> = self
-            .get_sorted_watchlist()
+            .get_raw_watchlist()
             .iter()
             .map(|(symbol, quote)| {
                 if let Some(q) = quote {

--- a/src/app/filter.rs
+++ b/src/app/filter.rs
@@ -36,7 +36,7 @@ impl App {
         self.news_selected = 0;
     }
 
-    pub fn get_sorted_watchlist(&self) -> Vec<(&String, Option<&StockQuote>)> {
+    pub fn get_raw_watchlist(&self) -> Vec<(&String, Option<&StockQuote>)> {
         self.config
             .current_watchlist()
             .symbols
@@ -46,7 +46,7 @@ impl App {
     }
 
     pub fn get_filtered_watchlist(&self) -> Vec<(&String, Option<&StockQuote>)> {
-        let mut items = self.get_sorted_watchlist();
+        let mut items = self.get_raw_watchlist();
         if self.search_active {
             items.retain(|(symbol, _)| symbol.to_uppercase().contains(&self.search_query));
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -9,7 +9,6 @@ use crate::api::{ChartData, NewsClient, NewsItem, StockQuote, YahooClient};
 use crate::ui::{NEWS_SORTABLE_COLUMNS, PORTFOLIO_SORTABLE_COLUMNS, WATCHLIST_SORTABLE_COLUMNS};
 use crate::config::Config;
 use anyhow::Result;
-use chrono::Local;
 use std::collections::HashMap;
 use tokio::time::Instant;
 
@@ -104,7 +103,6 @@ pub struct App {
     pub input_buffer: String,
     pub status_message: Option<String>,
     pub loading: bool,
-    pub last_updated: Option<String>,
     pub detail_symbol: Option<String>,
     pub detail_chart: Option<ChartData>,
     pub detail_news: Option<Vec<NewsItem>>,
@@ -145,7 +143,6 @@ impl App {
             input_buffer: String::new(),
             status_message: None,
             loading: false,
-            last_updated: None,
             detail_symbol: None,
             detail_chart: None,
             detail_news: None,
@@ -196,7 +193,6 @@ impl App {
         match self.client.get_quotes(symbols).await {
             Ok(quotes) => {
                 self.quotes = quotes;
-                self.last_updated = Some(Local::now().format("%H:%M:%S").to_string());
                 self.status_message = None;
             }
             Err(e) => {


### PR DESCRIPTION
## Summary
- Fix comment in `yahoo.rs`: `"CrsrfToken"` → `"CrumbStore"` to match actual code (closes #4)
- Remove unused `last_updated` field and `chrono::Local` import from `App` (closes #5)
- Rename `get_sorted_watchlist()` → `get_raw_watchlist()` to reflect insertion order (closes #6)

## Test plan
- [x] `cargo build` — compiles cleanly with no warnings
- [x] `cargo test` — all 5 tests pass
- [x] `cargo clippy` — no lint issues