### PR TITLE
Fix clock display flickering to Loading on every auto-refresh

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -176,9 +176,9 @@ impl App {
         })
     }
 
-    /// Collect symbols and set `loading = true`. Returns `None` for News view
+    /// Collect symbols for the current view. Returns `None` for News view
     /// or empty watchlists (no network call needed).
-    pub fn prepare_refresh(&mut self) -> Option<Vec<String>> {
+    pub fn refresh_symbols(&self) -> Option<Vec<String>> {
         let symbols: Vec<String> = match self.view_mode {
             ViewMode::Watchlist => self.config.current_watchlist().symbols.clone(),
             ViewMode::Portfolio => self.config.portfolio_symbols(),
@@ -187,8 +187,17 @@ impl App {
         if symbols.is_empty() {
             return None;
         }
-        self.loading = true;
         Some(symbols)
+    }
+
+    /// Collect symbols and set `loading = true`. Returns `None` for News view
+    /// or empty watchlists (no network call needed).
+    pub fn prepare_refresh(&mut self) -> Option<Vec<String>> {
+        let symbols = self.refresh_symbols();
+        if symbols.is_some() {
+            self.loading = true;
+        }
+        symbols
     }
 
     /// Execute the network fetch for the given symbols and clear `loading`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,12 +90,15 @@ async fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Resul
     let mut last_refresh = Instant::now() - refresh_interval; // Force immediate refresh
 
     loop {
-        // Auto-refresh quotes (skip in News view)
+        // Auto-refresh quotes silently (skip in News view).
+        // Uses refresh_symbols() instead of prepare_refresh() to avoid
+        // setting loading=true, which would flicker the clock display.
         if app.view_mode != ViewMode::News
             && last_refresh.elapsed() >= refresh_interval
-            && let Some(symbols) = app.prepare_refresh()
+            && let Some(symbols) = app.refresh_symbols()
         {
-            refresh_and_draw(terminal, app, &symbols, &mut last_refresh).await?;
+            app.execute_refresh(&symbols).await?;
+            last_refresh = Instant::now();
         }
 
         // Auto-refresh news when in News view


### PR DESCRIPTION
## Summary
- Auto-refresh was calling `prepare_refresh()` which sets `loading=true`, then drawing a frame showing `[Loading...]`, then fetching data — causing a visible flicker every refresh cycle
- Extracted `refresh_symbols()` to collect symbols without setting the loading flag
- Auto-refresh now fetches silently; user-triggered refreshes (pressing `r`, adding stocks, etc.) still show the loading indicator

## Test plan
- [x] Run the app and verify the clock display no longer flickers to `[Loading...]` on each auto-refresh
- [x] Press `r` to manually refresh and verify `[Loading...]` still appears briefly
- [x] Verify `cargo test` passes
- [x] Verify `cargo clippy` is clean