### PR TITLE
Fix news column empty on startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,9 @@ async fn run_app<B: Backend>(terminal: &mut Terminal<B>, app: &mut App) -> Resul
     let news_refresh_interval = Duration::from_secs(300); // 5 minutes
     let mut last_refresh = Instant::now() - refresh_interval; // Force immediate refresh
 
+    let urls = app.prepare_news_refresh();
+    refresh_news_and_draw(terminal, app, &urls).await?;
+
     loop {
         // Auto-refresh quotes (skip in News view)
         if app.view_mode != ViewMode::News


### PR DESCRIPTION
## Summary

- News view and `*` indicator column were empty until the user navigated to the News view or opened a stock detail popup
- Root cause: news loading was gated behind `ViewMode::News` in the event loop; no equivalent of the quote pre-aging trick existed for news
- Fix: load feeds unconditionally before the event loop in `run_app()`, matching how quotes force an immediate refresh via a pre-aged `Instant`

## Test plan

- [ ] Run app, confirm News view is populated immediately without pressing `p`
- [ ] Confirm `*` indicator in Watchlist shows recent news on startup
- [ ] Confirm `cargo build` passes
- [ ] Confirm `cargo clippy` passes